### PR TITLE
Use UnityWebRequest result comparisons

### DIFF
--- a/source/PluginDev/Assets/Extensions/CloudOnce/Providers/GooglePlayGames/GooglePlayGamesCloudProvider.cs
+++ b/source/PluginDev/Assets/Extensions/CloudOnce/Providers/GooglePlayGames/GooglePlayGamesCloudProvider.cs
@@ -418,7 +418,7 @@ namespace CloudOnce.Internal.Providers
             using (var request = UnityWebRequestTexture.GetTexture(url))
             {
                 yield return request.SendWebRequest();
-                if (request.isNetworkError || request.isHttpError)
+                if (request.result == UnityWebRequest.Result.ConnectionError || request.result == UnityWebRequest.Result.ProtocolError)
                 {
                     yield break;
                 }


### PR DESCRIPTION
## What changed?

Use the `result` object for checking connection/protocol errors.

As of Unity 2020.2, `isNetworkError` and `isHttpError` are obsolete! This fixes the following warnings:

```
'UnityWebRequest.isNetworkError' is obsolete: 'UnityWebRequest.isNetworkError is deprecated. Use (UnityWebRequest.result == UnityWebRequest.Result.ConnectionError) instead.'
'UnityWebRequest.isHttpError' is obsolete: 'UnityWebRequest.isHttpError is deprecated. Use (UnityWebRequest.result == UnityWebRequest.Result.ProtocolError) instead.'
